### PR TITLE
Add base for restricting interactions with crossplane providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ClusterPolicy` to allow managing `pkg.crossplane.io/v1/Provider` only to subject in the `customer:giantswarm:Employees` group
+
 ## [0.1.1] - 2022-08-05
 
 ## [0.1.0] - 2022-04-08

--- a/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
+++ b/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
@@ -9,9 +9,9 @@ metadata:
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: Crossplane
     policies.kyverno.io/description: >-
-      TODO
+      Restrict managing certain Crossplane resources to Giant Swarm only
 spec:
-  validationFailureAction: audit
+  validationFailureAction: enforce
   background: false
   rules:
     - name: restrict-providers
@@ -19,18 +19,11 @@ spec:
         resources:
           kinds:
             - pkg.crossplane.io/v1/Provider
-#        subjects:
-#          - kind: ServiceAccount
-#            name: kustomize-controller
-#            namespace: flux-giantswarm
       validate:
-        message: "Crossplane providers are only allowed to be created by flux-giantswarm/kustomize-controller"
+        message: "Crossplane providers are only allowed to be managed by subjects in the 'customer:giantswarm:Employees' group"
         deny:
           conditions:
             all:
-              - key: "{{ serviceAccountName }}"
-                operator: NotEquals
-                value: kustomize-controller
-              - key: "{{ serviceAccountNamespace }}"
-                operator: NotEquals
-                value: flux-giantswarm
+              - key: "customer:giantswarm:Employees"
+                operator: In
+                value: "{{ request.userInfo.groups }}"

--- a/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
+++ b/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
@@ -1,0 +1,36 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-usage-of-crossplane-crds
+  annotations:
+    policies.kyverno.io/title: Restrict Crossplane CRDs
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: Crossplane
+    policies.kyverno.io/description: >-
+      TODO
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: restrict-providers
+      match:
+        resources:
+          kinds:
+            - pkg.crossplane.io/v1/Provider
+#        subjects:
+#          - kind: ServiceAccount
+#            name: kustomize-controller
+#            namespace: flux-giantswarm
+      validate:
+        message: "Crossplane providers are only allowed to be created by flux-giantswarm/kustomize-controller"
+        deny:
+          conditions:
+            all:
+              - key: "{{ serviceAccountName }}"
+                operator: NotEquals
+                value: kustomize-controller
+              - key: "{{ serviceAccountNamespace }}"
+                operator: NotEquals
+                value: flux-giantswarm


### PR DESCRIPTION
### Description

Applied and tested on `gauss` with.

```
$ k apply --dry-run=server -f provider.yaml
provider.pkg.crossplane.io/provider-gcp created (server dry run)

$ ✗ k --dry-run=server apply --as system:serviceaccount:flux-giantswarm:kustomize-controller -f provider.yaml
provider.pkg.crossplane.io/provider-gcp created (server dry run)

$ ✗ k --dry-run=server apply --as system:serviceaccount:flux-system:kustomize-controller -f provider.yaml
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "pkg.crossplane.io/v1, Resource=providers", GroupVersionKind: "pkg.crossplane.io/v1, Kind=Provider"
Name: "provider-gcp", Namespace: ""
from server for: "provider.yaml": providers.pkg.crossplane.io "provider-gcp" is forbidden: User "system:serviceaccount:flux-system:kustomize-controller" cannot get resource "providers" in API group "pkg.crossplane.io" at the cluster scope

$ k --dry-run=server apply --as system:serviceaccount:default:automation -f provider.yaml
Error from server (Forbidden): error when creating "provider.yaml": providers.pkg.crossplane.io is forbidden: User "system:serviceaccount:default:automation" cannot create resource "providers" in API group "pkg.crossplane.io" at the cluster scope
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
