### PR TITLE
Change crossplane managers to `cluster-admin` cluster role or `giantswarm:giantswarm:giantswarm-admins` group members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `ClusterPolicy` to allow managing `pkg.crossplane.io/v1/Provider` only to subject in the `customer:giantswarm:Employees` group
+- Add `ClusterPolicy` to allow managing `pkg.crossplane.io/v1/Provider` only to subject in the `giantswarm:giantswarm:giantswarm-admins` group or with the `cluster-admin` cluster role
 
 ## [0.1.1] - 2022-08-05
 

--- a/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
+++ b/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
@@ -19,11 +19,15 @@ spec:
         resources:
           kinds:
             - pkg.crossplane.io/v1/Provider
+      exclude:
+        all:
+          - clusterRoles:
+              - cluster-admin
       validate:
-        message: "Crossplane providers are only allowed to be managed by subjects in the 'customer:giantswarm:Employees' group"
+        message: "Crossplane providers are only allowed to be managed by subjects in the 'giantswarm:giantswarm:giantswarm-admins' group or with the 'cluster-admin' cluster role"
         deny:
           conditions:
             all:
-              - key: "customer:giantswarm:Employees"
-                operator: In
+              - key: "giantswarm:giantswarm:giantswarm-admins"
+                operator: NotIn
                 value: "{{ request.userInfo.groups }}"


### PR DESCRIPTION
### Description

The current set of rules from yesterday are not good, correction here.

### Checklist

- [x] Update changelog in CHANGELOG.md.
