### PR TITLE
Block deployment of k8s-initiator-app on CAPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add policy to block `k8s-initiator-app` deployment on CAPA.
+
 ## [0.4.5] - 2024-03-18
 
 ### Removed

--- a/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
+++ b/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
@@ -1,5 +1,6 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
-{{- if and ( .Values.provider ) ( eq .Values.provider.kind "capa" ) }}
+{{- if .Values.provider  }}
+{{- if  eq .Values.provider.kind "capa"  }}
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -23,4 +24,5 @@ spec:
             operator: Equals
             value: "k8s-initiator-app"
   validationFailureAction: enforce
+{{- end }}
 {{- end }}

--- a/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
+++ b/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
@@ -1,5 +1,5 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
-{{- if eq .Values.provider.kind "capa" }}
+{{- if and ( .Values.provider.kind ) ( eq .Values.provider.kind "capa" ) }}
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
+++ b/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
@@ -1,0 +1,26 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if eq .provider.kind "capa" }}
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-k8s-initiator-app-deployment-capa
+spec:
+  background: true
+  failurePolicy: Fail
+  rules:
+    - match:
+        any:
+          - resources:
+              kinds:
+                - App
+      name: block-k8s-initiator-app-deployment-capa
+      validate:
+        message: K8s initiator app is not supported on CAPA.
+        deny:
+          conditions:
+          - key: "{{ `{{` }}request.object.spec.name{{ `}}` }}"
+            operator: Equals
+            value: "k8s-initiator-app"
+  validationFailureAction: enforce
+{{- end }}

--- a/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
+++ b/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
@@ -1,5 +1,5 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
-{{- if eq .provider.kind "capa" }}
+{{- if eq .Values.provider.kind "capa" }}
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
+++ b/helm/kyverno-policies-dx/templates/BlockK8sInitiatorAppCAPA.yaml
@@ -1,5 +1,5 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
-{{- if and ( .Values.provider.kind ) ( eq .Values.provider.kind "capa" ) }}
+{{- if and ( .Values.provider ) ( eq .Values.provider.kind "capa" ) }}
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/helm/kyverno-policies-dx/values.yaml
+++ b/helm/kyverno-policies-dx/values.yaml
@@ -8,3 +8,5 @@ Installation:
           ImagePullProgressDeadline: 10m
 
 clusterDescription: "Unnamed Cluster"
+provider:
+  kind: capa

--- a/helm/kyverno-policies-dx/values.yaml
+++ b/helm/kyverno-policies-dx/values.yaml
@@ -8,5 +8,3 @@ Installation:
           ImagePullProgressDeadline: 10m
 
 clusterDescription: "Unnamed Cluster"
-provider:
-  kind: capa

--- a/policies/dx/BlockK8sInitiatorAppCAPA.yaml
+++ b/policies/dx/BlockK8sInitiatorAppCAPA.yaml
@@ -1,0 +1,23 @@
+[[- if eq .provider.kind "capa" ]]
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-k8s-initiator-app-deployment-capa
+spec:
+  background: true
+  failurePolicy: Fail
+  rules:
+    - match:
+        any:
+          - resources:
+              kinds:
+                - App
+      name: block-k8s-initiator-app-deployment-capa
+      validate:
+        message: K8s initiator app is not supported on CAPA.
+        pattern:
+          spec:
+            name: "k8s-initiator-app"
+  validationFailureAction: enforce
+[[- end ]]

--- a/policies/dx/BlockK8sInitiatorAppCAPA.yaml
+++ b/policies/dx/BlockK8sInitiatorAppCAPA.yaml
@@ -16,8 +16,10 @@ spec:
       name: block-k8s-initiator-app-deployment-capa
       validate:
         message: K8s initiator app is not supported on CAPA.
-        pattern:
-          spec:
-            name: "k8s-initiator-app"
+        deny:
+          conditions:
+          - key: "{{request.object.spec.name}}"
+            operator: Equals
+            value: "k8s-initiator-app"
   validationFailureAction: enforce
 [[- end ]]

--- a/policies/dx/BlockK8sInitiatorAppCAPA.yaml
+++ b/policies/dx/BlockK8sInitiatorAppCAPA.yaml
@@ -1,4 +1,4 @@
-[[- if eq .provider.kind "capa" ]]
+[[- if eq .Values.provider.kind "capa" ]]
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policies/dx/BlockK8sInitiatorAppCAPA.yaml
+++ b/policies/dx/BlockK8sInitiatorAppCAPA.yaml
@@ -1,4 +1,4 @@
-[[- if eq .Values.provider.kind "capa" ]]
+[[- if and ( .Values.provider.kind ) ( eq .Values.provider.kind "capa" ) ]]
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policies/dx/BlockK8sInitiatorAppCAPA.yaml
+++ b/policies/dx/BlockK8sInitiatorAppCAPA.yaml
@@ -1,4 +1,5 @@
-[[- if and ( .Values.provider ) ( eq .Values.provider.kind "capa" ) ]]
+[[- if .Values.provider  ]]
+[[- if  eq .Values.provider.kind "capa"  ]]
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -22,4 +23,5 @@ spec:
             operator: Equals
             value: "k8s-initiator-app"
   validationFailureAction: enforce
+[[- end ]]
 [[- end ]]

--- a/policies/dx/BlockK8sInitiatorAppCAPA.yaml
+++ b/policies/dx/BlockK8sInitiatorAppCAPA.yaml
@@ -1,4 +1,4 @@
-[[- if and ( .Values.provider.kind ) ( eq .Values.provider.kind "capa" ) ]]
+[[- if and ( .Values.provider ) ( eq .Values.provider.kind "capa" ) ]]
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy


### PR DESCRIPTION
this is a vintage app and we want to make sure some customers accidentally(or on purpose) don't deploy that to CAPA as we no longer support it and the configuration should be done via proper values in `cluster-aws` chart



towards https://github.com/giantswarm/giantswarm/issues/30324