### PR TITLE
chore: migrate ClusterPolicies to ValidatingPolicies

### DIFF
--- a/.github/workflows/test-kyverno-vpol-policies-with-chainsaw.yaml
+++ b/.github/workflows/test-kyverno-vpol-policies-with-chainsaw.yaml
@@ -1,0 +1,51 @@
+name: "Test Kyverno ValidatingPolicies with Chainsaw"
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+env:
+  KYVERNO_POLICIES_APP_NAME: kyverno-policies-dx
+  # repository: kubernetes-sigs/kind
+  KIND_CLUSTER_NAME: chainsaw-kyverno-cluster
+  KIND_VERSION: v0.25.0
+  # repository: kindest/node
+  KUBERNETES_VERSION: v1.33.7
+  # repository: giantswarm/kyverno-crds
+  KYVERNO_VERSION: v1.16.0
+  HELM_VERSION: 4
+
+permissions: {}
+
+jobs:
+  test-policies:
+    name: "Test Kyverno ValidatingPolicies"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Chainsaw
+        uses: kyverno/action-install-chainsaw@06560d18422209e9c1e08e931d477d04bf2674c1 # v0.2.14
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          node_image: kindest/node:${{ env.KUBERNETES_VERSION }}
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      - name: Install Make
+        run: |
+          sudo apt-get update && sudo apt-get install make
+      - name: Install kyverno
+        run: |
+          make kind-get-kubeconfig install-kyverno
+      - name: Install extra resources
+        run: |
+          make install-extras
+      - name: Install Kyverno ValidatingPolicies
+        run: |
+          make install-vpol-policies
+      - name: Run Chainsaw tests
+        run: |
+          set -e
+          chainsaw test ./tests/vpol/chainsaw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update chart icon to use Kyverno-specific icon.
+- New optional switch `vpol.enabled` to move from the deprecated ClusterPolicy to the new ValidatingPolicy API
+- Update the `policies.kyverno.io/category` annotation to `Developer Experience`
 
 ## [0.8.3] - 2025-12-12
 

--- a/Makefile.gen.chainsaw.mk
+++ b/Makefile.gen.chainsaw.mk
@@ -35,6 +35,11 @@ install-policies:
 	touch tests/chainsaw/values.yaml
 	helm upgrade --install $(KYVERNO_POLICIES_APP_NAME) ./helm/$(KYVERNO_POLICIES_APP_NAME) --values ./tests/chainsaw/values.yaml
 
+.PHONY: install-vpol-policies
+install-vpol-policies:
+	touch tests/vpol/chainsaw/values.yaml
+	helm upgrade --install $(KYVERNO_POLICIES_APP_NAME) ./helm/$(KYVERNO_POLICIES_APP_NAME) --values ./tests/vpol/chainsaw/values.yaml
+
 .PHONY: install-extras
 install-extras:
 	hack/chainsaw-extra-resources.sh

--- a/helm/kyverno-policies-dx/templates/EnforceFallbackConfigScaledObjects.yaml
+++ b/helm/kyverno-policies-dx/templates/EnforceFallbackConfigScaledObjects.yaml
@@ -1,11 +1,12 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if not .Values.vpol.enabled }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: enforce-fallback-config-scaledobjects
   annotations:
     policies.kyverno.io/title: Enforce Fallback config for ScaledObjects
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: ScaledObject
@@ -60,3 +61,4 @@ rules:
   - get
   - list
   - watch
+{{- end }}

--- a/helm/kyverno-policies-dx/templates/EnforceGSRegistries.yaml
+++ b/helm/kyverno-policies-dx/templates/EnforceGSRegistries.yaml
@@ -1,11 +1,12 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if not .Values.vpol.enabled }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-image-registries
   annotations:
     policies.kyverno.io/title: Restrict Image Registries
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: Pod
@@ -30,3 +31,4 @@ spec:
         spec:
           containers:
           - image: "quay.io/giantswarm/* | docker.io/giantswarm/* | giantswarm/* | giantswarm.azurecr.io/giantswarm/* | giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/* | gsoci.azurecr.io/giantswarm/* | gsociprivate.azurecr.io/giantswarm/*"
+{{- end }}

--- a/helm/kyverno-policies-dx/templates/RestrictExternalSecretsServiceAccounts.yaml
+++ b/helm/kyverno-policies-dx/templates/RestrictExternalSecretsServiceAccounts.yaml
@@ -1,10 +1,17 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if not .Values.vpol.enabled }}
 {{- if or (.Capabilities.APIVersions.Has "external-secrets.io/v1alpha1/SecretStore") (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1/SecretStore") }}
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-external-secrets-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: SecretStore
 spec:
   background: true
   failurePolicy: Fail
@@ -55,6 +62,12 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-external-secrets-cluster-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Cluster Secret Store Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: ClusterSecretStore
 spec:
   background: true
   failurePolicy: Fail
@@ -96,4 +109,5 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 {{- end }}

--- a/helm/kyverno-policies-dx/templates/RestrictUsageOfCrossplaneCrds.yaml
+++ b/helm/kyverno-policies-dx/templates/RestrictUsageOfCrossplaneCrds.yaml
@@ -1,4 +1,5 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if not .Values.vpol.enabled }}
 {{- if .Capabilities.APIVersions.Has "pkg.crossplane.io/v1/Provider" }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -6,7 +7,7 @@ metadata:
   name: restrict-usage-of-crossplane-crds
   annotations:
     policies.kyverno.io/title: Restrict Crossplane CRDs
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: Crossplane
@@ -53,4 +54,5 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 {{- end }}

--- a/helm/kyverno-policies-dx/templates/vpol/BlockK8sInitiatorAppCAPA.yaml
+++ b/helm/kyverno-policies-dx/templates/vpol/BlockK8sInitiatorAppCAPA.yaml
@@ -1,35 +1,35 @@
 # THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
-{{- if and .Values.provider (not .Values.vpol.enabled) }}
+{{- if and .Values.provider .Values.vpol.enabled }}
 {{- if  eq .Values.provider.kind "capa"  }}
 ---
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
 metadata:
   name: block-k8s-initiator-app-deployment-capa
   annotations:
-    policies.kyverno.io/title: Block K8s Initiator App Deployment on CAPA
+    policies.kyverno.io/title: Block K8s initiator app deployment on CAPA
     policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: App
+    policies.kyverno.io/minversion: 1.16.0
 spec:
-  background: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["application.giantswarm.io"]
+      apiVersions: ["*"]
+      operations: [CREATE, UPDATE]
+      resources: [apps]
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
   failurePolicy: Fail
-  rules:
-    - match:
-        any:
-          - resources:
-              kinds:
-                - App
-      name: block-k8s-initiator-app-deployment-capa
-      validate:
-        message: K8s initiator app is not supported on CAPA.
-        deny:
-          conditions:
-          - key: "{{ `{{` }}request.object.spec.name{{ `}}` }}"
-            operator: Equals
-            value: "k8s-initiator-app"
-  validationFailureAction: Enforce
+  validationActions: [Deny]
+  validations:
+    - expression: >-
+        object.spec.name != "k8s-initiator-app"
+      message: K8s initiator app is not supported on CAPA.
 ---
 # https://github.com/giantswarm/giantswarm/issues/33418
 

--- a/helm/kyverno-policies-dx/templates/vpol/EnforceFallbackConfigScaledObjects.yaml
+++ b/helm/kyverno-policies-dx/templates/vpol/EnforceFallbackConfigScaledObjects.yaml
@@ -1,0 +1,63 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if .Values.vpol.enabled }}
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: enforce-fallback-config-scaledobjects
+  annotations:
+    policies.kyverno.io/title: Enforce Fallback config for ScaledObjects
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: ScaledObject
+    policies.kyverno.io/description: >-
+      ScaledObjects with prometheus or loki triggers should have a fallback configuration to ensure 
+      that they can handle cases where these metric-based scalers aren't working in a predictable way. 
+      The fallback section defines a number of replicas to fall back to if a scaler is in an error state.
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["keda.sh"]
+      operations: [CREATE, UPDATE]
+      apiVersions: ["v1alpha1"]
+      resources: [scaledobjects]
+  matchConditions:
+  - name: type
+    expression: >-
+      object.spec.triggers.exists(t, t.type == 'prometheus' || t.type == 'loki')
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      has(object.spec.fallback) &&
+      object.spec.fallback.failureThreshold.orValue(0) > 0 && 
+      object.spec.fallback.replicas.orValue(0) > 0
+    message: >-
+      ScaledObjects with prometheus or loki triggers must have a fallback config defined. 
+      The fallback section should include both failureThreshold and replicas fields to ensure 
+      reliable scaling behavior when these metric-based scalers encounter errors.
+      See the related doc for more information: 
+      https://intranet.giantswarm.io/docs/observability/horizontal-autoscaling/#mandatory-fallback-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:enforce-fallback-config-scaledobjects
+rules:
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/helm/kyverno-policies-dx/templates/vpol/EnforceGSRegistries.yaml
+++ b/helm/kyverno-policies-dx/templates/vpol/EnforceGSRegistries.yaml
@@ -1,0 +1,44 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if .Values.vpol.enabled }}
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-image-registries
+  annotations:
+    policies.kyverno.io/title: Restrict Image Registries
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Images from unknown, public registries can be of dubious quality and may not be
+      scanned and secured, representing a high degree of risk. Requiring use of known, approved
+      registries helps reduce threat exposure by ensuring image pulls only come from them. This
+      sample validates that container images only originate from Giant Swarm trusted registries.
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ['']
+      apiVersions: [v1]
+      operations: [CREATE, UPDATE]
+      resources: [pods]
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  validationActions: [Audit]
+  validations:
+  - expression: >-
+      object.spec.containers.all(c, 
+        c.image.startsWith("quay.io/giantswarm/") || 
+        c.image.startsWith("docker.io/giantswarm/") ||
+        c.image.startsWith("giantswarm/") ||
+        c.image.startsWith("giantswarm.azurecr.io/giantswarm/") ||
+        c.image.startsWith("giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/") ||
+        c.image.startsWith("gsoci.azurecr.io/giantswarm/") ||
+        c.image.startsWith("gsociprivate.azurecr.io/giantswarm/")
+      )
+    message: >-
+      Images must come from a trusted Giant Swarm registry.
+{{- end }}

--- a/helm/kyverno-policies-dx/templates/vpol/RestrictExternalSecretsServiceAccounts.yaml
+++ b/helm/kyverno-policies-dx/templates/vpol/RestrictExternalSecretsServiceAccounts.yaml
@@ -1,0 +1,113 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if .Values.vpol.enabled }}
+{{- if (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1/SecretStore") }}
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-external-secrets-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Secret Store Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: SecretStore
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["external-secrets.io"]
+      apiVersions: ["v1beta1"]
+      operations: [CREATE, UPDATE]
+      resources: [secretstores]
+  matchConditions:
+  - name: kubernetes-provider
+    expression: >-
+      has(object.spec.provider.kubernetes) &&
+      has(object.spec.provider.kubernetes.auth) &&
+      has(object.spec.provider.kubernetes.auth.serviceAccount)
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      object.spec.provider.kubernetes.auth.serviceAccount.namespace.contains("giantswarm") == false
+    message: SecretStore cannot use giantswarm namespaced service accounts for kubernetes provider.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:restrict-external-secrets-secret-store-service-accounts
+rules:
+- apiGroups:
+  - external-secrets.io
+  resources:
+  - secretstores
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+
+# This must be separate, because ClusterSecretStore is optional to install in `external-secrets`
+{{- if (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1/ClusterSecretStore") }}
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-external-secrets-cluster-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Cluster Secret Store Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: ClusterSecretStore
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["external-secrets.io"]
+      apiVersions: ["v1beta1"]
+      operations: [CREATE, UPDATE]
+      resources: [clustersecretstores]
+  matchConditions:
+  - name: kubernetes-provider
+    expression: >-
+      has(object.spec.provider.kubernetes) &&
+      has(object.spec.provider.kubernetes.auth) &&
+      has(object.spec.provider.kubernetes.auth.serviceAccount)
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      object.spec.provider.kubernetes.auth.serviceAccount.namespace.contains("giantswarm") == false
+    message: ClusterSecretStore cannot use giantswarm namespaced service accounts for kubernetes provider.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:restrict-external-secrets-cluster-secret-store-service-accounts
+rules:
+- apiGroups:
+  - external-secrets.io
+  resources:
+  - clustersecretstores
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+{{- end }}

--- a/helm/kyverno-policies-dx/templates/vpol/RestrictUsageOfCrossplaneCrds.yaml
+++ b/helm/kyverno-policies-dx/templates/vpol/RestrictUsageOfCrossplaneCrds.yaml
@@ -1,0 +1,59 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+{{- if .Values.vpol.enabled }}
+{{- if .Capabilities.APIVersions.Has "pkg.crossplane.io/v1/Provider" }}
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-usage-of-crossplane-crds
+  annotations:
+    policies.kyverno.io/title: Restrict Crossplane CRDs
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: Provider
+    policies.kyverno.io/description: >-
+      Restrict managing certain Crossplane resources to Giant Swarm only
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["pkg.crossplane.io"]
+      apiVersions: ["v1"]
+      operations: [CREATE, UPDATE]
+      resources: [providers]
+  matchConditions:
+  - name: cluster-admin
+    expression: >-
+      has(request.userInfo.groups) && request.userInfo.groups.exists(g, g == "kubeadm:cluster-admins") == false
+  evaluation:
+    background:
+      enabled: false
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      has(request.userInfo.groups) && request.userInfo.groups.exists(g, g == "giantswarm:giantswarm:giantswarm-admins")
+    message: Crossplane providers are only allowed to be managed by subjects in the 'giantswarm:giantswarm:giantswarm-admins' group or with the 'system:masters' cluster admin group
+---
+# https://github.com/giantswarm/giantswarm/issues/33418
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:restrict-usage-of-crossplane-crds
+rules:
+- apiGroups:
+  - pkg.crossplane.io
+  resources:
+  - providers
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+{{- end }}

--- a/helm/kyverno-policies-dx/values.schema.json
+++ b/helm/kyverno-policies-dx/values.schema.json
@@ -39,6 +39,14 @@
         },
         "clusterDescription": {
             "type": "string"
+        },
+        "vpol": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
         }
     },
     "type": "object"

--- a/helm/kyverno-policies-dx/values.yaml
+++ b/helm/kyverno-policies-dx/values.yaml
@@ -8,3 +8,6 @@ Installation:
           ImagePullProgressDeadline: 10m
 
 clusterDescription: "Unnamed Cluster"
+
+vpol:
+  enabled: false

--- a/policies/dx/EnforceFallbackConfigScaledObjects.yaml
+++ b/policies/dx/EnforceFallbackConfigScaledObjects.yaml
@@ -1,10 +1,11 @@
+[[- if not .Values.vpol.enabled ]]
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: enforce-fallback-config-scaledobjects
   annotations:
     policies.kyverno.io/title: Enforce Fallback config for ScaledObjects
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: ScaledObject
@@ -59,3 +60,4 @@ rules:
   - get
   - list
   - watch
+[[- end ]]

--- a/policies/dx/EnforceGSRegistries.yaml
+++ b/policies/dx/EnforceGSRegistries.yaml
@@ -1,10 +1,11 @@
+[[- if not .Values.vpol.enabled ]]
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-image-registries
   annotations:
     policies.kyverno.io/title: Restrict Image Registries
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: Pod
@@ -29,3 +30,4 @@ spec:
         spec:
           containers:
           - image: "quay.io/giantswarm/* | docker.io/giantswarm/* | giantswarm/* | giantswarm.azurecr.io/giantswarm/* | giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/* | gsoci.azurecr.io/giantswarm/* | gsociprivate.azurecr.io/giantswarm/*"
+[[- end ]]

--- a/policies/dx/RestrictExternalSecretsServiceAccounts.yaml
+++ b/policies/dx/RestrictExternalSecretsServiceAccounts.yaml
@@ -1,9 +1,16 @@
+[[- if not .Values.vpol.enabled ]]
 [[- if or (.Capabilities.APIVersions.Has "external-secrets.io/v1alpha1/SecretStore") (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1/SecretStore") ]]
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-external-secrets-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: SecretStore
 spec:
   background: true
   failurePolicy: Fail
@@ -54,6 +61,12 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-external-secrets-cluster-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Cluster Secret Store Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: ClusterSecretStore
 spec:
   background: true
   failurePolicy: Fail
@@ -95,4 +108,5 @@ rules:
   - get
   - list
   - watch
+[[- end ]]
 [[- end ]]

--- a/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
+++ b/policies/dx/RestrictUsageOfCrossplaneCrds.yaml
@@ -1,3 +1,4 @@
+[[- if not .Values.vpol.enabled ]]
 [[- if .Capabilities.APIVersions.Has "pkg.crossplane.io/v1/Provider" ]]
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -5,7 +6,7 @@ metadata:
   name: restrict-usage-of-crossplane-crds
   annotations:
     policies.kyverno.io/title: Restrict Crossplane CRDs
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: Crossplane
@@ -52,4 +53,5 @@ rules:
   - get
   - list
   - watch
+[[- end ]]
 [[- end ]]

--- a/policies/dx/vpol/BlockK8sInitiatorAppCAPA.yaml
+++ b/policies/dx/vpol/BlockK8sInitiatorAppCAPA.yaml
@@ -1,34 +1,34 @@
-[[- if and .Values.provider (not .Values.vpol.enabled) ]]
+[[- if and .Values.provider .Values.vpol.enabled ]]
 [[- if  eq .Values.provider.kind "capa"  ]]
 ---
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
 metadata:
   name: block-k8s-initiator-app-deployment-capa
   annotations:
-    policies.kyverno.io/title: Block K8s Initiator App Deployment on CAPA
+    policies.kyverno.io/title: Block K8s initiator app deployment on CAPA
     policies.kyverno.io/category: Developer Experience
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: App
+    policies.kyverno.io/minversion: 1.16.0
 spec:
-  background: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["application.giantswarm.io"]
+      apiVersions: ["*"]
+      operations: [CREATE, UPDATE]
+      resources: [apps]
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
   failurePolicy: Fail
-  rules:
-    - match:
-        any:
-          - resources:
-              kinds:
-                - App
-      name: block-k8s-initiator-app-deployment-capa
-      validate:
-        message: K8s initiator app is not supported on CAPA.
-        deny:
-          conditions:
-          - key: "{{request.object.spec.name}}"
-            operator: Equals
-            value: "k8s-initiator-app"
-  validationFailureAction: Enforce
+  validationActions: [Deny]
+  validations:
+    - expression: >-
+        object.spec.name != "k8s-initiator-app"
+      message: K8s initiator app is not supported on CAPA.
 ---
 # https://github.com/giantswarm/giantswarm/issues/33418
 

--- a/policies/dx/vpol/EnforceFallbackConfigScaledObjects.yaml
+++ b/policies/dx/vpol/EnforceFallbackConfigScaledObjects.yaml
@@ -1,0 +1,62 @@
+[[- if .Values.vpol.enabled ]]
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: enforce-fallback-config-scaledobjects
+  annotations:
+    policies.kyverno.io/title: Enforce Fallback config for ScaledObjects
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: ScaledObject
+    policies.kyverno.io/description: >-
+      ScaledObjects with prometheus or loki triggers should have a fallback configuration to ensure 
+      that they can handle cases where these metric-based scalers aren't working in a predictable way. 
+      The fallback section defines a number of replicas to fall back to if a scaler is in an error state.
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["keda.sh"]
+      operations: [CREATE, UPDATE]
+      apiVersions: ["v1alpha1"]
+      resources: [scaledobjects]
+  matchConditions:
+  - name: type
+    expression: >-
+      object.spec.triggers.exists(t, t.type == 'prometheus' || t.type == 'loki')
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      has(object.spec.fallback) &&
+      object.spec.fallback.failureThreshold.orValue(0) > 0 && 
+      object.spec.fallback.replicas.orValue(0) > 0
+    message: >-
+      ScaledObjects with prometheus or loki triggers must have a fallback config defined. 
+      The fallback section should include both failureThreshold and replicas fields to ensure 
+      reliable scaling behavior when these metric-based scalers encounter errors.
+      See the related doc for more information: 
+      https://intranet.giantswarm.io/docs/observability/horizontal-autoscaling/#mandatory-fallback-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:enforce-fallback-config-scaledobjects
+rules:
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - get
+  - list
+  - watch
+[[- end ]]

--- a/policies/dx/vpol/EnforceGSRegistries.yaml
+++ b/policies/dx/vpol/EnforceGSRegistries.yaml
@@ -1,0 +1,43 @@
+[[- if .Values.vpol.enabled ]]
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-image-registries
+  annotations:
+    policies.kyverno.io/title: Restrict Image Registries
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Images from unknown, public registries can be of dubious quality and may not be
+      scanned and secured, representing a high degree of risk. Requiring use of known, approved
+      registries helps reduce threat exposure by ensuring image pulls only come from them. This
+      sample validates that container images only originate from Giant Swarm trusted registries.
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ['']
+      apiVersions: [v1]
+      operations: [CREATE, UPDATE]
+      resources: [pods]
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  validationActions: [Audit]
+  validations:
+  - expression: >-
+      object.spec.containers.all(c, 
+        c.image.startsWith("quay.io/giantswarm/") || 
+        c.image.startsWith("docker.io/giantswarm/") ||
+        c.image.startsWith("giantswarm/") ||
+        c.image.startsWith("giantswarm.azurecr.io/giantswarm/") ||
+        c.image.startsWith("giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/") ||
+        c.image.startsWith("gsoci.azurecr.io/giantswarm/") ||
+        c.image.startsWith("gsociprivate.azurecr.io/giantswarm/")
+      )
+    message: >-
+      Images must come from a trusted Giant Swarm registry.
+[[- end ]]

--- a/policies/dx/vpol/RestrictExternalSecretsServiceAccounts.yaml
+++ b/policies/dx/vpol/RestrictExternalSecretsServiceAccounts.yaml
@@ -1,0 +1,112 @@
+[[- if .Values.vpol.enabled ]]
+[[- if (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1/SecretStore") ]]
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-external-secrets-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Secret Store Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: SecretStore
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["external-secrets.io"]
+      apiVersions: ["v1beta1"]
+      operations: [CREATE, UPDATE]
+      resources: [secretstores]
+  matchConditions:
+  - name: kubernetes-provider
+    expression: >-
+      has(object.spec.provider.kubernetes) &&
+      has(object.spec.provider.kubernetes.auth) &&
+      has(object.spec.provider.kubernetes.auth.serviceAccount)
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      object.spec.provider.kubernetes.auth.serviceAccount.namespace.contains("giantswarm") == false
+    message: SecretStore cannot use giantswarm namespaced service accounts for kubernetes provider.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:restrict-external-secrets-secret-store-service-accounts
+rules:
+- apiGroups:
+  - external-secrets.io
+  resources:
+  - secretstores
+  verbs:
+  - get
+  - list
+  - watch
+[[- end ]]
+
+# This must be separate, because ClusterSecretStore is optional to install in `external-secrets`
+[[- if (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1/ClusterSecretStore") ]]
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-external-secrets-cluster-secret-store-service-accounts
+  annotations:
+    policies.kyverno.io/title: Restrict External Secrets Cluster Secret Store Service Accounts
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: ClusterSecretStore
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["external-secrets.io"]
+      apiVersions: ["v1beta1"]
+      operations: [CREATE, UPDATE]
+      resources: [clustersecretstores]
+  matchConditions:
+  - name: kubernetes-provider
+    expression: >-
+      has(object.spec.provider.kubernetes) &&
+      has(object.spec.provider.kubernetes.auth) &&
+      has(object.spec.provider.kubernetes.auth.serviceAccount)
+  evaluation:
+    background:
+      enabled: true
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      object.spec.provider.kubernetes.auth.serviceAccount.namespace.contains("giantswarm") == false
+    message: ClusterSecretStore cannot use giantswarm namespaced service accounts for kubernetes provider.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:restrict-external-secrets-cluster-secret-store-service-accounts
+rules:
+- apiGroups:
+  - external-secrets.io
+  resources:
+  - clustersecretstores
+  verbs:
+  - get
+  - list
+  - watch
+[[- end ]]
+[[- end ]]

--- a/policies/dx/vpol/RestrictUsageOfCrossplaneCrds.yaml
+++ b/policies/dx/vpol/RestrictUsageOfCrossplaneCrds.yaml
@@ -1,0 +1,58 @@
+[[- if .Values.vpol.enabled ]]
+[[- if .Capabilities.APIVersions.Has "pkg.crossplane.io/v1/Provider" ]]
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-usage-of-crossplane-crds
+  annotations:
+    policies.kyverno.io/title: Restrict Crossplane CRDs
+    policies.kyverno.io/category: Developer Experience
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.16.0
+    policies.kyverno.io/subject: Provider
+    policies.kyverno.io/description: >-
+      Restrict managing certain Crossplane resources to Giant Swarm only
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["pkg.crossplane.io"]
+      apiVersions: ["v1"]
+      operations: [CREATE, UPDATE]
+      resources: [providers]
+  matchConditions:
+  - name: cluster-admin
+    expression: >-
+      has(request.userInfo.groups) && request.userInfo.groups.exists(g, g == "kubeadm:cluster-admins") == false
+  evaluation:
+    background:
+      enabled: false
+    admission:
+      enabled: true
+  failurePolicy: Fail
+  validationActions: [Deny]
+  validations:
+  - expression: >-
+      has(request.userInfo.groups) && request.userInfo.groups.exists(g, g == "giantswarm:giantswarm:giantswarm-admins")
+    message: Crossplane providers are only allowed to be managed by subjects in the 'giantswarm:giantswarm:giantswarm-admins' group or with the 'system:masters' cluster admin group
+---
+# https://github.com/giantswarm/giantswarm/issues/33418
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+  name: kyverno:gs-dx:restrict-usage-of-crossplane-crds
+rules:
+- apiGroups:
+  - pkg.crossplane.io
+  resources:
+  - providers
+  verbs:
+  - get
+  - list
+  - watch
+[[- end ]]
+[[- end ]]

--- a/tests/vpol/chainsaw/_steps-templates/validating-policy-ready.yaml
+++ b/tests/vpol/chainsaw/_steps-templates/validating-policy-ready.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/steptemplate-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: validating-policy-ready
+spec:
+  try:
+  - assert:
+      template: true
+      resource:
+        apiVersion: policies.kyverno.io/v1beta1
+        kind: ValidatingPolicy
+        metadata:
+          name: ($name)
+        status:
+          conditionStatus:
+            (conditions[?type == 'WebhookConfigured']):
+            - message: Webhook configured.
+              reason: Succeeded
+              status: "True"
+              type: WebhookConfigured
+            (conditions[?type == 'RBACPermissionsGranted']):
+            - message: Policy is ready for reporting.
+              reason: Succeeded
+              status: "True"
+              type: RBACPermissionsGranted
+            ready: true

--- a/tests/vpol/chainsaw/block-k8s-initiator-app-deployment-capa/chainsaw-test.yaml
+++ b/tests/vpol/chainsaw/block-k8s-initiator-app-deployment-capa/chainsaw-test.yaml
@@ -1,0 +1,48 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: block-k8s-initiator-app-deployment-capa
+spec:
+  steps:
+  - name: check-policy-ready
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: block-k8s-initiator-app-deployment-capa
+
+  - name: allow-app-with-different-name
+    try:
+    - apply:
+        resource:
+          apiVersion: application.giantswarm.io/v1alpha1
+          kind: App
+          metadata:
+            name: test-allowed-app
+          spec:
+            name: some-other-app
+            namespace: default
+            catalog: default
+            version: "1.0.0"
+            kubeConfig:
+              inCluster: false
+
+  - name: deny-k8s-initiator-app
+    try:
+    - apply:
+        resource:
+          apiVersion: application.giantswarm.io/v1alpha1
+          kind: App
+          metadata:
+            name: test-denied-app
+          spec:
+            name: k8s-initiator-app
+            namespace: default
+            catalog: default
+            version: "1.0.0"
+            kubeConfig:
+              inCluster: false
+        expect:
+        - check:
+            ($error != null): true

--- a/tests/vpol/chainsaw/check-policy-ready/chainsaw-test.yaml
+++ b/tests/vpol/chainsaw/check-policy-ready/chainsaw-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: check-policy-is-ready
+spec:
+  steps:
+  - name: check-block-k8s-initiator-app-deployment-capa
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: block-k8s-initiator-app-deployment-capa
+
+  - name: check-enforce-fallback-config-scaledobjects
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: enforce-fallback-config-scaledobjects
+
+  - name: check-restrict-external-secrets-secret-store-service-accounts
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-external-secrets-secret-store-service-accounts
+
+  - name: check-restrict-external-secrets-cluster-secret-store-service-accounts
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-external-secrets-cluster-secret-store-service-accounts
+
+  - name: check-restrict-image-registries
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-image-registries
+
+  - name: check-restrict-usage-of-crossplane-crds
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-usage-of-crossplane-crds

--- a/tests/vpol/chainsaw/enforce-fallback-config-scaledobjects/chainsaw-test.yaml
+++ b/tests/vpol/chainsaw/enforce-fallback-config-scaledobjects/chainsaw-test.yaml
@@ -1,0 +1,117 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: enforce-fallback-config-scaledobjects
+spec:
+  steps:
+  - name: check-policy-ready
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: enforce-fallback-config-scaledobjects
+
+  - name: allow-prometheus-trigger-with-fallback
+    try:
+    - apply:
+        resource:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          metadata:
+            name: test-prometheus-with-fallback
+          spec:
+            scaleTargetRef:
+              name: test-deployment
+            triggers:
+            - type: prometheus
+              metadata:
+                serverAddress: http://prometheus:9090
+                metricName: http_requests_total
+                threshold: "100"
+                query: sum(rate(http_requests_total[2m]))
+            fallback:
+              failureThreshold: 3
+              replicas: 2
+
+  - name: allow-loki-trigger-with-fallback
+    try:
+    - apply:
+        resource:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          metadata:
+            name: test-loki-with-fallback
+          spec:
+            scaleTargetRef:
+              name: test-deployment
+            triggers:
+            - type: loki
+              metadata:
+                serverAddress: http://loki:3100
+                query: sum(rate({app="test"}[2m]))
+                threshold: "100"
+            fallback:
+              failureThreshold: 3
+              replicas: 1
+
+  - name: allow-cpu-trigger-without-fallback
+    # Precondition not met (no prometheus/loki trigger), so fallback is not required
+    try:
+    - apply:
+        resource:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          metadata:
+            name: test-cpu-trigger
+          spec:
+            scaleTargetRef:
+              name: test-deployment
+            triggers:
+            - type: cpu
+              metadata:
+                type: Utilization
+                value: "80"
+
+  - name: deny-prometheus-trigger-without-fallback
+    try:
+    - apply:
+        resource:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          metadata:
+            name: test-prometheus-no-fallback
+          spec:
+            scaleTargetRef:
+              name: test-deployment
+            triggers:
+            - type: prometheus
+              metadata:
+                serverAddress: http://prometheus:9090
+                metricName: http_requests_total
+                threshold: "100"
+                query: sum(rate(http_requests_total[2m]))
+        expect:
+        - check:
+            ($error != null): true
+
+  - name: deny-loki-trigger-without-fallback
+    try:
+    - apply:
+        resource:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          metadata:
+            name: test-loki-no-fallback
+          spec:
+            scaleTargetRef:
+              name: test-deployment
+            triggers:
+            - type: loki
+              metadata:
+                serverAddress: http://loki:3100
+                query: sum(rate({app="test"}[2m]))
+                threshold: "100"
+        expect:
+        - check:
+            ($error != null): true

--- a/tests/vpol/chainsaw/restrict-external-secrets-cluster-secret-store-service-accounts/chainsaw-test.yaml
+++ b/tests/vpol/chainsaw/restrict-external-secrets-cluster-secret-store-service-accounts/chainsaw-test.yaml
@@ -1,0 +1,62 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-external-secrets-cluster-secret-store-service-accounts
+spec:
+  steps:
+  - name: check-policy-ready
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-external-secrets-cluster-secret-store-service-accounts
+
+  - name: allow-clustersecretstore-without-kubernetes-provider
+    try:
+    - apply:
+        resource:
+          apiVersion: external-secrets.io/v1beta1
+          kind: ClusterSecretStore
+          metadata:
+            name: test-no-kubernetes-provider
+          spec:
+            provider:
+              aws:
+                service: SecretsManager
+                region: us-east-1
+
+  - name: allow-clustersecretstore-with-non-giantswarm-namespace
+    try:
+    - apply:
+        resource:
+          apiVersion: external-secrets.io/v1beta1
+          kind: ClusterSecretStore
+          metadata:
+            name: test-allowed-namespace
+          spec:
+            provider:
+              kubernetes:
+                auth:
+                  serviceAccount:
+                    name: my-sa
+                    namespace: default
+
+  - name: deny-clustersecretstore-with-giantswarm-namespace
+    try:
+    - apply:
+        resource:
+          apiVersion: external-secrets.io/v1beta1
+          kind: ClusterSecretStore
+          metadata:
+            name: test-denied-giantswarm-namespace
+          spec:
+            provider:
+              kubernetes:
+                auth:
+                  serviceAccount:
+                    name: giantswarm-sa
+                    namespace: giantswarm
+        expect:
+        - check:
+            ($error != null): true

--- a/tests/vpol/chainsaw/restrict-external-secrets-secret-store-service-accounts/chainsaw-test.yaml
+++ b/tests/vpol/chainsaw/restrict-external-secrets-secret-store-service-accounts/chainsaw-test.yaml
@@ -1,0 +1,62 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-external-secrets-secret-store-service-accounts
+spec:
+  steps:
+  - name: check-policy-ready
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-external-secrets-secret-store-service-accounts
+
+  - name: allow-secretstore-without-kubernetes-provider
+    try:
+    - apply:
+        resource:
+          apiVersion: external-secrets.io/v1beta1
+          kind: SecretStore
+          metadata:
+            name: test-no-kubernetes-provider
+          spec:
+            provider:
+              aws:
+                service: SecretsManager
+                region: us-east-1
+
+  - name: allow-secretstore-with-non-giantswarm-namespace
+    try:
+    - apply:
+        resource:
+          apiVersion: external-secrets.io/v1beta1
+          kind: SecretStore
+          metadata:
+            name: test-allowed-namespace
+          spec:
+            provider:
+              kubernetes:
+                auth:
+                  serviceAccount:
+                    name: my-sa
+                    namespace: default
+
+  - name: deny-secretstore-with-giantswarm-namespace
+    try:
+    - apply:
+        resource:
+          apiVersion: external-secrets.io/v1beta1
+          kind: SecretStore
+          metadata:
+            name: test-denied-giantswarm-namespace
+          spec:
+            provider:
+              kubernetes:
+                auth:
+                  serviceAccount:
+                    name: giantswarm-sa
+                    namespace: giantswarm
+        expect:
+        - check:
+            ($error != null): true

--- a/tests/vpol/chainsaw/restrict-image-registries/chainsaw-test.yaml
+++ b/tests/vpol/chainsaw/restrict-image-registries/chainsaw-test.yaml
@@ -1,0 +1,58 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-image-registries
+spec:
+  steps:
+  - name: check-policy-ready
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-image-registries
+
+  - name: allow-pod-with-gs-registry
+    try:
+    - apply:
+        file: pod-gs-registry.yaml
+
+  - name: allow-pod-with-quay-gs-registry
+    try:
+    - apply:
+        file: pod-quay-gs-registry.yaml
+
+  # Policy is in Audit mode — non-compliant pods are admitted but generate a PolicyReport entry.
+  - name: allow-pod-with-external-registry-audit-mode
+    try:
+    - apply:
+        file: pod-external-registry.yaml
+
+  # Kyverno creates an EphemeralReport immediately on admission for audit-mode policy violations.
+  # Assert one exists in the test namespace owned by the non-compliant pod with a fail result.
+  - name: assert-ephemeral-report-created
+    try:
+    - sleep:
+        duration: 30s
+    - script:
+        content: "kubectl get pod test-external-registry -o jsonpath='{.metadata.uid}' -n $NAMESPACE"
+        outputs:
+        - name: uid
+          value: ($stdout)
+    - assert:
+        template: true
+        resource:
+          apiVersion: reports.kyverno.io/v1
+          kind: EphemeralReport
+          metadata:
+            namespace: ($namespace)
+            labels:
+              audit.kyverno.io/resource.uid: ($uid)
+            ownerReferences:
+            - kind: Pod
+              name: test-external-registry
+          spec:
+            results:
+              - category: Developer Experience
+                policy: restrict-image-registries
+                result: fail

--- a/tests/vpol/chainsaw/restrict-image-registries/pod-external-registry.yaml
+++ b/tests/vpol/chainsaw/restrict-image-registries/pod-external-registry.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-external-registry
+spec:
+  containers:
+  - name: app
+    image: nginx:latest
+  restartPolicy: Never

--- a/tests/vpol/chainsaw/restrict-image-registries/pod-gs-registry.yaml
+++ b/tests/vpol/chainsaw/restrict-image-registries/pod-gs-registry.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-gs-registry
+spec:
+  containers:
+  - name: app
+    image: gsoci.azurecr.io/giantswarm/helloworld:latest
+  restartPolicy: Never

--- a/tests/vpol/chainsaw/restrict-image-registries/pod-quay-gs-registry.yaml
+++ b/tests/vpol/chainsaw/restrict-image-registries/pod-quay-gs-registry.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-quay-gs-registry
+spec:
+  containers:
+  - name: app
+    image: quay.io/giantswarm/helloworld:latest
+  restartPolicy: Never

--- a/tests/vpol/chainsaw/restrict-usage-of-crossplane-crds/chainsaw-test.yaml
+++ b/tests/vpol/chainsaw/restrict-usage-of-crossplane-crds/chainsaw-test.yaml
@@ -1,0 +1,107 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-usage-of-crossplane-crds
+spec:
+  steps:
+  - name: check-policy-ready
+    use:
+      template: ../_steps-templates/validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: restrict-usage-of-crossplane-crds
+
+  # Set up a ServiceAccount with Provider create permissions but without cluster-admin.
+  # This is used to test the deny case via impersonation.
+  - name: setup-test-serviceaccount
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: crossplane-test-sa
+            namespace: default
+    - apply:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: crossplane-provider-creator
+          rules:
+          - apiGroups:
+            - pkg.crossplane.io
+            resources:
+            - providers
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+    - apply:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: crossplane-test-sa-provider-creator
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: crossplane-provider-creator
+          subjects:
+          - kind: ServiceAccount
+            name: crossplane-test-sa
+            namespace: default
+
+  # The test runner uses cluster-admin kubeconfig, which is excluded by the policy.
+  - name: allow-provider-as-cluster-admin
+    try:
+    - apply:
+        resource:
+          apiVersion: pkg.crossplane.io/v1
+          kind: Provider
+          metadata:
+            name: provider-aws-admin
+          spec:
+            package: xpkg.upbound.io/upbound/provider-aws:v0.18.0
+
+  # Impersonate a non-admin ServiceAccount (not in giantswarm:giantswarm:giantswarm-admins group).
+  # The policy should deny the request.
+  - name: deny-provider-as-non-admin
+    try:
+    - script:
+        content: |
+          if kubectl apply --as=system:serviceaccount:default:crossplane-test-sa -f - <<'EOF'
+          apiVersion: pkg.crossplane.io/v1
+          kind: Provider
+          metadata:
+            name: provider-aws-denied
+          spec:
+            package: xpkg.upbound.io/upbound/provider-aws:v0.18.0
+          EOF
+          then
+            echo "ERROR: Expected Kyverno to deny this request but it was allowed"
+            exit 1
+          fi
+
+  - name: cleanup-cluster-scoped-resources
+    try:
+    - delete:
+        ref:
+          apiVersion: pkg.crossplane.io/v1
+          kind: Provider
+          name: provider-aws-admin
+    - delete:
+        ref:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: crossplane-test-sa-provider-creator
+    - delete:
+        ref:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          name: crossplane-provider-creator

--- a/tests/vpol/chainsaw/values.yaml
+++ b/tests/vpol/chainsaw/values.yaml
@@ -1,0 +1,5 @@
+provider:
+  kind: capa
+
+vpol:
+  enabled: true


### PR DESCRIPTION
## Issue

part of https://github.com/giantswarm/giantswarm/issues/36831

## Changes

**New Kyverno ValidatingPolicies:**

* Added policies to:
  - Block deployment of the K8s initiator app on CAPA clusters.
  - Enforce fallback configuration for KEDA ScaledObjects with Prometheus or Loki triggers.
  - Restrict container image sources to trusted Giant Swarm registries.
  - Restrict usage of Crossplane CRDs to Giant Swarm admins.
  - Restrict service account usage in External Secrets (both `SecretStore` and `ClusterSecretStore`).
