### PR TITLE
fix: own install-cel-policies in Makefile.custom.mk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Own the `install-cel-policies` make target in `Makefile.custom.mk`. It lives in the devctl-generated `Makefile.gen.chainsaw.mk` today, but the current template no longer emits it, so the next `align-files` run removes it and breaks the hand-written `test-kyverno-vpol-policies-with-chainsaw.yaml` workflow, whose `Install Kyverno ValidatingPolicies` step calls it (`make: *** No rule to make target 'install-cel-policies'`). The target is specific to this repository — it is the only one with a `tests/cel/` suite — so it belongs in the file `align-files` does not regenerate.
 - Update chart icon to use Kyverno-specific icon.
 - New optional switch `cel.enabled` to move from the deprecated ClusterPolicy to the new ValidatingPolicy API
 - Update the `policies.kyverno.io/category` annotation to `Developer Experience`

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -21,3 +21,14 @@ clean: ## Delete test manifests from kind cluster.
 dabs: generate
 	dabs.sh --generate-metadata --chart-dir helm/kyverno-policies-dx
 	
+##@ Test (ValidatingPolicies)
+
+# Owned here rather than in Makefile.gen.chainsaw.mk because it is specific to this
+# repository: only kyverno-policies-dx has a tests/cel/ suite. devctl dropped the target
+# from the shared chainsaw template, which broke the hand-written
+# .github/workflows/test-kyverno-vpol-policies-with-chainsaw.yaml that calls it. Keeping
+# it in this file, which align-files does not regenerate, makes it survive.
+.PHONY: install-cel-policies
+install-cel-policies: ## Install the chart with the ValidatingPolicy (CEL) test values.
+	touch tests/cel/chainsaw/values.yaml
+	helm upgrade --install $(KYVERNO_POLICIES_APP_NAME) ./helm/$(KYVERNO_POLICIES_APP_NAME) --values ./tests/cel/chainsaw/values.yaml


### PR DESCRIPTION
## Problem

The open align PR #193 fails on `Test Kyverno ValidatingPolicies`:

```
make: *** No rule to make target 'install-cel-policies'.  Stop.
##[error]Process completed with exit code 2.
```

`install-cel-policies` currently lives in the devctl-generated `Makefile.gen.chainsaw.mk`, but the current template **no longer emits it** — the align diff deletes it:

```diff
-.PHONY: install-cel-policies
-install-cel-policies:
-	touch tests/cel/chainsaw/values.yaml
-	helm upgrade --install $(KYVERNO_POLICIES_APP_NAME) ./helm/$(KYVERNO_POLICIES_APP_NAME) --values ./tests/cel/chainsaw/values.yaml
```

Meanwhile `.github/workflows/test-kyverno-vpol-policies-with-chainsaw.yaml` is **hand-written** (no `zz_generated.` prefix) and its `Install Kyverno ValidatingPolicies` step still calls it. So the generated makefile and a repo-owned workflow drift apart, and the ValidatingPolicy test suite stops running.

Worth being precise about the blast radius: `main` is fine today, because the generated file still has the target there. This breaks the moment the align PR merges — or the next time `align-files` regenerates the file.

## Fix

Move the target into `Makefile.custom.mk`, which `align-files` does not regenerate.

This is the right home for it rather than a devctl change: the target is specific to this repository — it's the only one with a `tests/cel/` suite — so it doesn't belong in a template shared by every kyverno-policies repo. devctl dropping it looks deliberate.

## Verified both states

With the generated definition **still present** (i.e. `main` today):

```
$ KYVERNO_POLICIES_APP_NAME=kyverno-policies-dx make -n install-cel-policies
Makefile.gen.chainsaw.mk:40: warning: overriding commands for target `install-cel-policies'
Makefile.custom.mk:33: warning: ignoring old commands for target `install-cel-policies'
touch tests/cel/chainsaw/values.yaml
helm upgrade --install kyverno-policies-dx ./helm/kyverno-policies-dx --values ./tests/cel/chainsaw/values.yaml
```

The duplicate-recipe warning is the same kind this repo already emits for `dabs`, and the generated copy wins since it's included later — identical commands either way.

With the generated definition **removed** (simulating post-align):

```
touch tests/cel/chainsaw/values.yaml
helm upgrade --install kyverno-policies-dx ./helm/kyverno-policies-dx --values ./tests/cel/chainsaw/values.yaml
```

Resolves from `Makefile.custom.mk` with the correct commands. `$(KYVERNO_POLICIES_APP_NAME)` comes from the workflow's job-level `env`, so it expands to `kyverno-policies-dx` and matches the `helm/kyverno-policies-dx` chart directory.

## Note on timing

Merging this does **not** immediately turn #193 green. That PR's CI runs against `teams-alignment-branch`, which the bot force-pushes from a fresh clone of `main` — so it only picks this up on the next `align-files` run.
